### PR TITLE
Upgrade to Detox 9.1.2 and support Xcode 10.1 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,52 @@
 # Detox on AppCenter React Native Demo Project
 
 ## Background
-
 This sample project demonstrates running Detox tests prior to a regular MS [AppCenter](https://appcenter.ms/) build
-* On React Native 0.56.0
-* With Detox 8
-* And Mocha runner, currently
+* on React Native 0.56.0
+* with Detox 9.1.2 in Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2/badge)](https://appcenter.ms)
+* and Mocha 5.2.0 test runner, currently
 
 ## Requirements
-
-* Make sure you have Xcode installed (tested with Xcode 9.4.1).
-* Make sure you have node installed (`brew install node` or via nvm etc, node 8.X and up is required_
-* Make sure you have react-native dependencies installed:
+Make sure you have installed:
+* Xcode (tested with Xcode 9.4.1)
+* xcpretty (`gem install xcpretty` - https://github.com/supermarin/xcpretty)
+* Node.js (`brew install node@8` or `nvm install`. Node version 8.X or newer is _required_)
+* react-native dependencies:
    * watchman is installed (`brew install watchman`)
 
-### Step 1: Npm install
+See software installation commands in `appcenter-post-clone.sh` for any other dependencies that may need to be installed to build and run this project anywhere other than in MS [AppCenter](https://appcenter.ms/).
 
+### Step 1: Install Dependencies
 * Run `npm install`.
 
 ## To test Release build of your app
-### Step 2: Build 
+### Step 2: Build
 * Build the demo project
- 
  ```sh
  npx detox build --configuration ios.sim.release
  ```
- 
-### Step 3: Test 
+
+### Step 3: Test
 * Run tests on the demo project
- 
  ```sh
  npx detox test --configuration ios.sim.release
  ```
  This action will open a new simulator and run the tests on it.
 
 ## To test Debug build of your app
-### Step 2: Build 
+### Step 2: Build
 * Build the demo project
- 
  ```sh
  npx detox build --configuration ios.sim.debug
  ```
- 
-### Step 3: Test 
 
+### Step 3: Test
  * start react-native packager
- 
-  ```sh
+ ```sh
  npm run start
  ```
+
  * Run tests on the demo project
- 
  ```sh
  npx detox test --configuration ios.sim.debug
  ```

--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 ## Background
 This sample project demonstrates running Detox tests prior to a regular MS [AppCenter](https://appcenter.ms/) build
 * on React Native 0.56.0
-* with Detox 9.1.2 in Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2/badge)](https://appcenter.ms)
+* with Detox 9.1.2 built by Xcode 10.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2-xcode_10.1/badge)](https://appcenter.ms)
 * and Mocha 5.2.0 test runner, currently
+
+This project has also run Detox tests successfully from AppCenter with:-
+* Detox 9.1.2 built by Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2/badge)](https://appcenter.ms)
+* _or_ Detox 9.0.4 built by Xcode 10.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.0.4-xcode_10.1/badge)](https://appcenter.ms)
+* _or_ Detox 9.0.4 built by Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.0.4/badge)](https://appcenter.ms)
 
 ## Requirements
 Make sure you have installed:
-* Xcode (tested with Xcode 9.4.1)
+* Xcode (tested with Xcode 9.4.1 and Xcode 10.1)
 * xcpretty (`gem install xcpretty` - https://github.com/supermarin/xcpretty)
 * Node.js (`brew install node@8` or `nvm install`. Node version 8.X or newer is _required_)
 * react-native dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-react-native",
-  "version": "0.0.1",
+  "version": "9.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1973,9 +1973,9 @@
       "integrity": "sha512-+w6B0Uo0ZvTSzDkXjoBCTNK0oe+aVL+yPi7kwGZm8hd8+Nj1AFPoxoq1Bl/mEu/G/ivOkUc1LRqVR0XeWFUzuA=="
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
       "dev": true
     },
     "bplist-creator": {
@@ -2050,9 +2050,9 @@
       }
     },
     "bunyan-debug-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bunyan-debug-stream/-/bunyan-debug-stream-1.1.0.tgz",
-      "integrity": "sha512-Yu3mVHHMyfnBkC5uKNpMSXKoiY+wF7vnoRdY7n+mNtH0bJMKcf0FmdAGtkBk0LuQmieMryY8yqdot9IP9kqI0A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bunyan-debug-stream/-/bunyan-debug-stream-1.1.1.tgz",
+      "integrity": "sha512-jJbQ1gXUL6vMmZVdbaTFK1v1sGa7axLrSQQwkB6HU9HCPTzsw2HsKcPHm1vgXZlEck/4IvEuRwg/9+083YelCg==",
       "dev": true,
       "requires": {
         "colors": "^1.0.3",
@@ -2227,9 +2227,9 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "commander": {
@@ -2442,9 +2442,9 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
     "detox": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/detox/-/detox-8.1.1.tgz",
-      "integrity": "sha512-5ovUjOpTlpgr13NXs1faoxQwiIQY5H57GPflDzVM4EOHBxy9gL6j5sjs+mlhfomNAqbi3fEd8qknESA7C6OHLQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/detox/-/detox-9.1.2.tgz",
+      "integrity": "sha512-pVyyDHPekYxzQK+sComeYXau5oNG1ZyMGjhEB8ecSbg5EaK1MhIyaLDxri4eDXVnOgLizFP9gqHZSgPcpdITRg==",
       "dev": true,
       "requires": {
         "bunyan": "^1.8.12",
@@ -2457,6 +2457,7 @@
         "lodash": "^4.17.5",
         "minimist": "^1.2.0",
         "proper-lockfile": "^3.0.2",
+        "sanitize-filename": "^1.6.1",
         "shell-utils": "^1.0.9",
         "tail": "^1.2.3",
         "telnet-client": "0.15.3",
@@ -2465,9 +2466,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.0.tgz",
-          "integrity": "sha512-477o1hdVORiFlZxw8wgsXYCef3lh0zl/OV0FTftqiDxJSWw6dPQ2ipS4k20J2qBcsmsmLKSyr2iFrf9e3JGi4w==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
           "dev": true
         },
         "fs-extra": {
@@ -2489,12 +2490,6 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
         }
       }
     },
@@ -4475,9 +4470,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
       "dev": true,
       "optional": true
     },
@@ -4531,7 +4526,7 @@
         },
         "rimraf": {
           "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "dev": true,
           "optional": true,
@@ -4601,7 +4596,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "dev": true,
       "optional": true
@@ -5051,13 +5046,14 @@
       }
     },
     "proper-lockfile": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.0.2.tgz",
-      "integrity": "sha512-SDrSRyuKE1jM9b2kdpL6SA78wgG+M+fZKe2zbWkURsshOzUmoOornXQcasKQRP9hGhMoEILNpSbWcYoymoB5cA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
+      "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
-        "retry": "^0.10.1"
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "pseudomap": {
@@ -5425,9 +5421,9 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rimraf": {
@@ -5772,6 +5768,15 @@
             "to-regex": "^3.0.2"
           }
         }
+      }
+    },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "sax": {
@@ -6221,9 +6226,9 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tail": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tail/-/tail-1.3.0.tgz",
-      "integrity": "sha512-9Blh9bCW3lQyr10UAh//7K3kqljspQ+NcMa5nwVXicnxFXfiUizZrEC71kqVKPhe2UcMLXDEb+YnqR+tzvOEDQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tail/-/tail-1.4.0.tgz",
+      "integrity": "sha512-wjwfZw6wcMFTB1Po7NFUf4TdCDwX8duZjdTMhnHBEC677Q6mFRcVZE7f/nZDhG2Fpf/wEEKOJP9L7/b11/vlHQ==",
       "dev": true
     },
     "telnet-client": {
@@ -6389,6 +6394,15 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6542,6 +6556,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-demo-react-native",
-  "version": "0.0.1",
+  "version": "9.1.2",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "detox": "^8.1.1"
+    "detox": "9.1.2"
   },
   "detox": {
     "test-runner": "mocha",
@@ -22,13 +22,13 @@
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-        "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "build": "set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7 Plus"
       },
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-        "build": "xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "build": "set -o pipefail && xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7 Plus"
       },

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
-        "build": "set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
+        "build": "set -o pipefail && export CODE_SIGNING_REQUIRED=NO && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7 Plus"
       },
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/example.app",
-        "build": "set -o pipefail && xcodebuild -project ios/example.xcodeproj -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
+        "build": "set -o pipefail && xcodebuild -project ios/example.xcodeproj -UseNewBuildSystem=NO -scheme example -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7 Plus"
       },


### PR DESCRIPTION
Xcode 10.1 can successful build this example project locally and demo Detox 9.1.2 tests run in App Center by adding `-UseNewBuildSystem=NO` to the build command in package.json to not use Xcode’s new build system.

**Refer official example Detox build command lines:-**
- https://github.com/wix/Detox/blob/master/detox/test/package.json#L43
- https://github.com/wix/Detox/blob/master/examples/demo-react-native/package.json#L29

**Status of running this example project's Detox tests in my AppCenter account and build the app:** 
* Detox 9.1.2 built by Xcode 10.1 [![Detox 9.1.2 built by Xcode 10.1](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2-xcode_10.1/badge)](https://appcenter.ms)
* Detox 9.1.2 built by Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.1.2/badge)](https://appcenter.ms)
* Detox 9.0.4 built by Xcode 10.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.0.4-xcode_10.1/badge)](https://appcenter.ms)
* Detox 9.0.4 built by Xcode 9.4.1 [![Build status](https://build.appcenter.ms/v0.1/apps/b941d881-bc98-48d1-8bc6-8ddf76856b36/branches/detox_9.0.4/badge)](https://appcenter.ms)
